### PR TITLE
Allow numbers inside the BASE URL

### DIFF
--- a/public/v4/apps/supabase-gotrue.yml
+++ b/public/v4/apps/supabase-gotrue.yml
@@ -52,7 +52,7 @@ caproverOneClickApp:
         - id: '$$cap_site_url'
           label: SITE_URL
           description: The base URL at which your site is located.
-          validRegex: /^[a-zA-Z]+://([a-zA-Z]+(\.[a-zA-Z]+)+)$/
+          validRegex: /^[a-zA-Z]+://([a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+)$/
         - id: $$cap_jwt_secret
           label: JWT Secret
           description: A 32+ character string (do not expose in version control)


### PR DESCRIPTION
While normally avoided, some domains contains numbers, so I'm proposing to add 0-9 to your regex, if gotrue support it.